### PR TITLE
pf4: guard the glass term in RecalcFilters, as its siblings already are

### DIFF
--- a/opticsApp/src/pf4.st
+++ b/opticsApp/src/pf4.st
@@ -692,7 +692,7 @@ void RecalcFilters(double keV,short* bits,double* xmit,int d,int b,int z1,
             }
             xmit[i] =  exp(-xAl*1000./absLenAl);
             xmit[i] *= exp(-xTi*1000./absLenTi);
-            xmit[i] *= exp(-xGlass*1000./absLenGlass);
+            if (xGlass > 0) xmit[i] *= exp(-xGlass*1000./absLenGlass);
 			if (xOther1 > 0) xmit[i] *= exp(-xOther1*1000./absLenOther1);
 			if (xOther2 > 0) xmit[i] *= exp(-xOther2*1000./absLenOther2);
 			if (xOther3 > 0) xmit[i] *= exp(-xOther3*1000./absLenOther3);


### PR DESCRIPTION
`RecalcFilters` applies the glass absorption term unconditionally, while the four "Other" terms immediately below it are each guarded on their thickness. `GlassAbsorptionLength` returns `0` below 2 keV ("this routine only good above 2 keV"), so with no glass blade in the beam (`xGlass == 0` — the ordinary case for any bank without a glass filter) the term is `exp(-(0.0/0.0)) = exp(NaN) = NaN`, and it multiplies into all 16 combination transmissions.

The NaNs then defeat `sortDecreasing`, whose comparison `arr[ii] < a` is false for every NaN, so the array is left in its original order and the recommended "best filter combination" is just combination 0. No error, no alarm, no diagnostic.

Guarding the glass term on `xGlass`, exactly as its four siblings guard on theirs, removes the 0/0. A blade that is not in the beam contributes no attenuation — which is what the sibling guards already encode.

Verified with a driver compiled against `AlAbsorptionLength`/`TiAbsorptionLength`/`GlassAbsorptionLength`/`sortDecreasing` lifted verbatim from the file: an Al,Al,Ti,Ti bank at 1.5 keV goes from 16/16 NaN and an unsorted ranking to 0/16 NaN and a correct ranking; at ≥2 keV, and with a glass blade at 8 keV, all 16 transmissions are bit-identical before and after.

The Al and Ti terms were audited and deliberately left alone: `AlAbsorptionLength` returns no zero anywhere in 0.001–60 keV, and `TiAbsorptionLength`'s below-1-keV branch returns `1./0 = +Inf` rather than 0, so neither divide can be 0/0.

This removes the NaN only. It does not address a glass blade that *is* in the beam below 2 keV, where `exp(-xGlass*1000./0) = 0` reports the blade fully opaque — the same "0 as a no-data sentinel, consumed as a divisor" shape as `OtherAbsorptionLength`'s `0` return. That is a separate defect, left for a separate change.