### PR TITLE
pf4: guard the j+1 interpolation lookup against an out-of-bounds read

### DIFF
--- a/opticsApp/src/pf4.st
+++ b/opticsApp/src/pf4.st
@@ -634,7 +634,7 @@ double OtherAbsorptionLength(double keV, char *species) {
 	for (j=0; j<filtermat[i].numEntries; j++) {
 		if (keV < filtermat[i].keV[j]) break;
 	}
-	if (j >= filtermat[i].numEntries) {
+	if (j >= filtermat[i].numEntries - 1) {
 		/*printf("pf4.st: Energy '%f' not found in filter data\n", keV);*/
 		return(0.);
 	}


### PR DESCRIPTION
# pf4: guard the `j+1` interpolation lookup against an out-of-bounds read

## Summary

`OtherAbsorptionLength()` in `opticsApp/src/pf4.st` interpolates a filter
material's mass-attenuation coefficient between table entries `j` and `j+1`,
but the bounds check before that access only guards `j` (`if (j >=
numEntries)`). When the requested energy falls in a material's **top** bin,
`j == numEntries - 1` passes the guard and the code then dereferences
`keV[j+1]` / `mu[j+1]` at index `numEntries` — one past the end of the
per-material arrays. This patch tightens the guard to `j >= numEntries - 1`
so the `j+1` access is always in bounds, matching the guarding already done
by the sibling routine in `filterDrive.st`.

## The defect

`OtherAbsorptionLength()` (`opticsApp/src/pf4.st`):

```c
for (j=0; j<filtermat[i].numEntries; j++) {
    if (keV < filtermat[i].keV[j]) break;
}
if (j >= filtermat[i].numEntries) {          /* guards keV[j], not keV[j+1] */
    return(0.);
}
frac = (keV - filtermat[i].keV[j]) / (filtermat[i].keV[j+1] - filtermat[i].keV[j]);
mu   = filtermat[i].mu[j]  + frac * (filtermat[i].mu[j+1]  - filtermat[i].mu[j]);
```

The arrays are fixed-size `float keV[NUM_ENTRIES]` / `float mu[NUM_ENTRIES]`
with `NUM_ENTRIES == 274` (`chantler.h`). The existing guard only ensures
`j < numEntries`; the interpolation then reads index `j+1`, which reaches
`numEntries` when `j == numEntries - 1`.

## Reachability — this is a real read, not defensive noise

The condition `j == numEntries - 1` is reached whenever the requested energy
lies in a material's highest tabulated bin. It becomes a genuine
out-of-bounds read for the material whose table is completely full:

- `chantler.c` gives **Pb** `numEntries = 274`, i.e. exactly `NUM_ENTRIES`.
- Pb is the **last** element of `filtermat[]`.

So for any energy between Pb's last two table points (`keV[272] = 405` and
`keV[273] = 432.95`), the loop stops at `j = 273`, the guard passes, and the
code reads `keV[274]` / `mu[274]` — past the end of Pb's arrays. Because the
struct layout is `{... float keV[274]; float mu[274];}`, `&keV[274]` aliases
`mu[0]`: C silently reads Pb's `mu[0]` (a mass-attenuation coefficient) and
uses it as an *energy in keV*, while `mu[274]` reads 4 bytes past the end of
`filtermat[]` entirely. The value that comes back is adjacent-memory garbage,
not merely an imprecise extrapolation; any recompilation, struct reordering,
or ASan build can change or trap it.

Materials with `numEntries < NUM_ENTRIES` do not read past `filtermat[]` on
their own top bin, but they still read one element beyond their own valid
data (into the zero-padded tail of the same arrays); the guard fixes both.

## The fix

```diff
-	if (j >= filtermat[i].numEntries) {
+	if (j >= filtermat[i].numEntries - 1) {
```

This mirrors the guarding idiom in the sibling routine
`OtherFilterCurve()` / the interpolation in `filterDrive.st`, which indexes
`[j-1, j]` and guards `if ((j < 1) | (j >= numEntries))` — i.e. it always
bounds the *highest* index it will touch. Here the highest index touched is
`j+1`, so the guard must reject `j == numEntries - 1`. For energies in the
top bin the routine now returns `0.` (the same "energy not found" path it
already uses above the table), instead of interpolating off the end.

## Scope / family check

`rg '\[j\+1\]'` over `opticsApp/src/` returns only these two lines
(`pf4.st:642-643`); every other table interpolation in the module
(`filterDrive.st`, and the array-copy loop later in `pf4.st`) indexes at or
below `j` and is already bounded by its `j >= numEntries` guard. This is a
single-site fix.

## Testing

Not compiled locally — this checkout has no EPICS support tree / sequencer
(`snc`) configured, so the `.st` cannot be built here. The change is a
one-token tightening of an existing bounds check (`numEntries` →
`numEntries - 1`) with no change to types, control flow, or the surrounding
interpolation math; CI compiles it. The out-of-bounds condition and the
aliasing described above were confirmed by reading `chantler.c` /
`chantler.h` (Pb: `numEntries = 274 == NUM_ENTRIES`, last `filtermat[]`
entry).
