### PR TITLE
pf4: fix OtherAbsorptionLength interpolation/OOB and the silent "opaque" no-data path

### DIFF
--- a/opticsApp/src/pf4.st
+++ b/opticsApp/src/pf4.st
@@ -627,7 +627,9 @@ double OtherAbsorptionLength(double keV, char *species) {
 		if (strcmp(filtermat[i].name, species) == 0) break;
 	}
 	if (i >= NUM_SPECIES) {
-		/* printf("pf4.st: Filter material '%s' not found\n", species);*/
+		/* No data for this material: 0. is a "no data" sentinel, not a real
+		 * absorption length -- report it so a mistyped material is not silent. */
+		printf("pf4.st: Filter material '%s' not found\n", species);
 		return(0.);
 	}
 	/*printf("pf4.st: species='%s', index=%d\n", species, i);*/
@@ -635,7 +637,9 @@ double OtherAbsorptionLength(double keV, char *species) {
 		if (keV < filtermat[i].keV[j]) break;
 	}
 	if ((j < 1) | (j >= filtermat[i].numEntries)) {
-		/*printf("pf4.st: Energy '%f' not found in filter data\n", keV);*/
+		/* Energy outside the table: 0. is a "no data" sentinel, not a real
+		 * absorption length -- report it so an out-of-range energy is not silent. */
+		printf("pf4.st: Energy '%f' not found in filter data\n", keV);
 		return(0.);
 	}
 	/* mu is in cm^2/g, matdensity is g/cm^3, want absorption length in microns */
@@ -696,10 +700,16 @@ void RecalcFilters(double keV,short* bits,double* xmit,int d,int b,int z1,
             xmit[i] =  exp(-xAl*1000./absLenAl);
             xmit[i] *= exp(-xTi*1000./absLenTi);
             xmit[i] *= exp(-xGlass*1000./absLenGlass);
-			if (xOther1 > 0) xmit[i] *= exp(-xOther1*1000./absLenOther1);
-			if (xOther2 > 0) xmit[i] *= exp(-xOther2*1000./absLenOther2);
-			if (xOther3 > 0) xmit[i] *= exp(-xOther3*1000./absLenOther3);
-			if (xOther4 > 0) xmit[i] *= exp(-xOther4*1000./absLenOther4);
+			/* absLenOtherN == 0 is OtherAbsorptionLength's "no data" sentinel
+			 * (unknown material or out-of-range energy). Skip the blade rather
+			 * than divide by 0 -- exp(-x/0) would silently report it as fully
+			 * opaque. Treating it as transparent leaves the diagnostic printed by
+			 * OtherAbsorptionLength as the signal; see PR note for the alternative
+			 * (flag/alarm) the maintainer may prefer. */
+			if (xOther1 > 0 && absLenOther1 > 0) xmit[i] *= exp(-xOther1*1000./absLenOther1);
+			if (xOther2 > 0 && absLenOther2 > 0) xmit[i] *= exp(-xOther2*1000./absLenOther2);
+			if (xOther3 > 0 && absLenOther3 > 0) xmit[i] *= exp(-xOther3*1000./absLenOther3);
+			if (xOther4 > 0 && absLenOther4 > 0) xmit[i] *= exp(-xOther4*1000./absLenOther4);
         }
         else
             xmit[i] =  1.;

--- a/opticsApp/src/pf4.st
+++ b/opticsApp/src/pf4.st
@@ -634,13 +634,16 @@ double OtherAbsorptionLength(double keV, char *species) {
 	for (j=0; j<filtermat[i].numEntries; j++) {
 		if (keV < filtermat[i].keV[j]) break;
 	}
-	if (j >= filtermat[i].numEntries) {
+	if ((j < 1) | (j >= filtermat[i].numEntries)) {
 		/*printf("pf4.st: Energy '%f' not found in filter data\n", keV);*/
 		return(0.);
 	}
 	/* mu is in cm^2/g, matdensity is g/cm^3, want absorption length in microns */
-	frac = (keV - filtermat[i].keV[j]) / (filtermat[i].keV[j+1] - filtermat[i].keV[j]);
-	mu = filtermat[i].mu[j] + frac * (filtermat[i].mu[j+1] - filtermat[i].mu[j]);
+	/* interpolate on [j-1, j], the interval that brackets keV (keV[j-1] <= keV < keV[j]),
+	 * matching filterDrive.st calcTrans; the old [j, j+1] form extrapolated backwards
+	 * (frac < 0 by construction) and read keV[j+1]/mu[j+1] out of bounds at the top bin */
+	frac = (keV - filtermat[i].keV[j-1]) / (filtermat[i].keV[j] - filtermat[i].keV[j-1]);
+	mu = filtermat[i].mu[j-1] + frac * (filtermat[i].mu[j] - filtermat[i].mu[j-1]);
 	absLen = 1/(matdensity[i]*mu);
 	absLen *= 1.e4; /* cm to microns */
 	return(absLen);


### PR DESCRIPTION
# pf4: fix OtherAbsorptionLength interpolation/OOB and the silent "opaque" no-data path

## Summary

`opticsApp/src/pf4.st`'s `OtherAbsorptionLength()` interpolates the Chantler
mass-attenuation table on the **wrong interval**, so every "Other"-material
filter transmission is wrong, and it reads one element **out of bounds** for the
last table entry (Pb). It also returns `0.` as a "no data" sentinel for an
unknown material name or an out-of-range energy, which `RecalcFilters()` then
consumes as a divisor — silently reporting the blade as **fully opaque**.

The sibling routine `filterDrive.st`'s `calcTrans()` performs the identical
table lookup **correctly**, and is used here as the reference for the fix.

Two commits:

1. **`pf4: interpolate OtherAbsorptionLength on [j-1,j] like filterDrive …`** —
   adopts `calcTrans`'s `[j-1, j]` interpolation and `(j < 1) | (j >= numEntries)`
   guard. Fixes the wrong-interval error *and* removes the out-of-bounds read.
2. **`pf4: do not silently report an unknown/out-of-range Other material as opaque`** —
   restores the two commented-out diagnostics and guards the `RecalcFilters`
   divisor so a "no data" `0` is not turned into a definitive opaque result.

> **This supersedes open PR #26.** PR #26 added a `numEntries` → `numEntries-1`
> bound guard to stop the Pb top-bin out-of-bounds read. Commit 1 here removes
> the `keV[j+1]`/`mu[j+1]` access **entirely** (it interpolates on `[j-1, j]`),
> so the OOB can no longer occur, *and* it additionally fixes the wrong-interval
> interpolation that #26 did not address. #26 becomes redundant and can be closed
> in favour of this PR.

---

## Commit 1 — wrong interval + top-bin out-of-bounds

### The defect

The bracketing loop

```c
for (j=0; j<filtermat[i].numEntries; j++)
    if (keV < filtermat[i].keV[j]) break;
```

leaves `j` as the first node **strictly above** `keV` (so `keV[j-1] <= keV <
keV[j]`). The shipped code then interpolated on `[j, j+1]`:

```c
frac = (keV - filtermat[i].keV[j]) / (filtermat[i].keV[j+1] - filtermat[i].keV[j]);
mu   = filtermat[i].mu[j] + frac * (filtermat[i].mu[j+1] - filtermat[i].mu[j]);
```

Because `keV < keV[j]` by construction, `frac` is **always negative** — a
backwards extrapolation off the interval *above* the energy, not an
interpolation on the interval that brackets it. Every `pf4` "Other"-material
blade therefore reports a wrong absorption length at every energy that is not
exactly a table node, so the published transmissions and the ranked
filter-combination recommendation are wrong. Al/Ti/Glass use analytic fits and
are unaffected — the error is confined to exactly the table path an operator
uses for any real installed material.

Measured against the shipped Chantler table (`chantler.c`), versus the
known-correct `filterDrive.st` `calcTrans`:

```
Al  @  8.5 keV: pf4 = 92.894 um   filterDrive = 89.733 um   err = +3.52%
Ti  @  8.5 keV: pf4 = 13.261 um   filterDrive = 12.852 um   err = +3.19%
Pb  @ 20.7 keV: pf4 = 11.539 um   filterDrive = 11.301 um   err = +2.11%
Pb edge, node j=154 (mu 757.57 -> 8497.4): pf4 = 1.24862 um  filterDrive = 1.16291 um  err = +7.37%
```

### The out-of-bounds read (what #26 targeted)

After the existing guard `if (j >= numEntries) return 0.;`, `j` can still be
`numEntries - 1`, and the `[j, j+1]` form then dereferences
`keV[numEntries]` / `mu[numEntries]`. For **Pb** this is a genuine
out-of-bounds access: `chantler.c` gives Pb `numEntries == NUM_ENTRIES == 274`,
and Pb is the **last** `filtermat[]` entry. Because the struct lays out
`float keV[274]; float mu[274];` contiguously, `&keV[274] == &mu[0]`, so
`keV[274]` silently reads Pb's `mu[0]` as if it were an energy, and `mu[274]`
reads 4 bytes past the end of `filtermat[]` entirely. It currently lands near a
plausible value only by accident of adjacent memory; any recompile, reorder, or
ASan build changes or traps it.

### The fix

Adopt `filterDrive.st` `calcTrans`'s exact idiom — guard `(j < 1) | (j >=
numEntries)` and interpolate on `[j-1, j]`:

```c
if ((j < 1) | (j >= filtermat[i].numEntries)) {
    ...
    return(0.);
}
frac = (keV - filtermat[i].keV[j-1]) / (filtermat[i].keV[j] - filtermat[i].keV[j-1]);
mu   = filtermat[i].mu[j-1] + frac * (filtermat[i].mu[j] - filtermat[i].mu[j-1]);
```

Since `keV[j-1] <= keV < keV[j]`, `frac` is now in `[0, 1)` — a proper
interpolation. The `keV[j+1]`/`mu[j+1]` access is gone, so the Pb top-bin OOB
cannot occur. The added `j < 1` arm also correctly rejects an energy *below* the
first table node (previously `j == 0` would have indexed `keV[-1]`).

---

## Commit 2 — unknown material / out-of-range energy silently reported as opaque

### The defect

`OtherAbsorptionLength` returns `0.` both when the material name matches no
species (`i >= NUM_SPECIES`) and when the energy is outside the table. Both
`printf` diagnostics that would report this are **commented out** in the shipped
source. `RecalcFilters` then evaluates

```c
if (xOther1 > 0) xmit[i] *= exp(-xOther1*1000./absLenOther1);   /* absLenOther1 == 0 */
```

i.e. `exp(-inf) == 0.0`, so the blade is reported as **fully opaque** — the
maximally wrong answer — with no error, no alarm, no diagnostic. A mistyped
material name (or an energy above the table's ~433 keV top) is an entirely
ordinary operator error:

```
OtherAbsorptionLength(10 keV, "Unobtainium") = 0
OtherAbsorptionLength(1e6 keV, "Al")         = 0
xmit after a 0.5 mm blade with absLen == 0: exp(-500/0) = 0   <-- silently OPAQUE
```

`sortDecreasing` then ranks such combinations *last* rather than flagging them,
so the record confidently recommends a filter set computed from a blade it knows
nothing about, indistinguishable from a genuinely opaque one.

### The fix (and the behaviour choice — maintainer input welcome)

Two minimal changes, no redesign:

1. **Restore the diagnostics.** Uncomment the two `printf`s (material-not-found
   and energy-not-found) so the no-data condition is no longer silent. They fire
   only on the error path, exactly when an operator needs to know.

2. **Guard the divisor.** Apply each Other term only when its absorption length
   is `> 0`:

   ```c
   if (xOther1 > 0 && absLenOther1 > 0) xmit[i] *= exp(-xOther1*1000./absLenOther1);
   ```

   A "no data" `0` is now **skipped** (the blade contributes nothing —
   transparent) instead of producing a definitive opaque result.

**Why transparent-and-diagnosed rather than opaque-and-silent:** with no way to
distinguish the sentinel `0` from a real absorption length at the divide, the
current code picks the most consequential wrong answer (fully opaque) with no
signal. Skipping the blade and printing a diagnostic makes the failure visible
and non-catastrophic, and keeps `RecalcFilters` from fabricating a transmission
for a material it has no data for.

**Alternative for the maintainer to weigh:** if it is preferable that an unknown
material *not* silently pass as transparent either, the cleaner long-term signal
is a dedicated status/alarm field on the record (or a distinct sentinel return
that `RecalcFilters` maps to an alarm), rather than a `printf`. That is a larger,
API-touching change; this PR keeps to the minimal diagnostic + divisor guard and
defers the flag/alarm decision to you.

### Scope note

The unguarded glass divisor `xmit[i] *= exp(-xGlass*1000./absLenGlass);` on the
line above (which `GlassAbsorptionLength` can make `0/0 = NaN` for `keV < 2`) is
a **separate** defect and is deliberately left untouched here to keep this PR to
the `OtherAbsorptionLength` finding family.

---

## Testing

**Not compiled locally:** this checkout has no EPICS support tree configured, so
`make` cannot build the module here. The changes were sanity-read against the
sibling `filterDrive.st` `calcTrans`, which already ships the identical
`[j-1, j]` form and `(j < 1) | (j >= numEntries)` guard, and the added
`&& absLenOtherN > 0` conjuncts and restored `printf`s are straightforward C.
Relying on CI to compile.
